### PR TITLE
fix: removed arrayCallbackFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,6 @@ Default: `undefined`
 
 Called for every final result.
 
-#### arrayCallbackFn
-
-Type: `function`<br>
-Default: `undefined`
-
-Called when `useArraySelector` is `false` for every array where the direct non-array parent is matched.
-
 #### joined
 
 Type: `boolean`<br>

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Called for every final result.
 Type: `function`<br>
 Default: `undefined`
 
-Called when `useArraySelector` is `false` for every array that contains at least one direct child matched by a needle.
+Called when `useArraySelector` is `false` for every array where the direct non-array parent is matched.
 
 #### joined
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Iff function is defined and returns false, the entry is excluded from the final 
 
 This method is conceptually similar to [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).
 
+#### callbackFn
+
+Type: `function`<br>
+Default: `undefined`
+
+Called for every final result.
+
 #### breakFn
 
 Type: `function`<br>
@@ -67,13 +74,6 @@ Default: `undefined`
 
 Called for every key that could be (part of) a matching key.
 If function is defined and returns true, all nested entries under the current key are excluded from search and from the final result.
-
-#### callbackFn
-
-Type: `function`<br>
-Default: `undefined`
-
-Called for every final result.
 
 #### joined
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,6 @@ const find = (haystack, searches, pathIn, parents, ctx) => {
 
   const result = [];
   if (ctx.useArraySelector === false && Array.isArray(haystack)) {
-    if (ctx.arrayCallbackFn !== undefined) {
-      if (searches.some(s => compiler.isMatch(s))) {
-        ctx.arrayCallbackFn(formatPath(pathIn, ctx), haystack, compiler.getMeta(searches, parents));
-      }
-    }
     if (recurseHaystack) {
       for (let i = 0; i < haystack.length; i += 1) {
         result.push(...find(haystack[i], searches, pathIn.concat(i), parents, ctx));
@@ -80,7 +75,6 @@ module.exports = (needles, {
   filterFn = undefined,
   breakFn = undefined,
   callbackFn = undefined,
-  arrayCallbackFn = undefined,
   joined = true,
   escapePaths = true,
   useArraySelector = true
@@ -90,7 +84,6 @@ module.exports = (needles, {
     filterFn,
     breakFn,
     callbackFn,
-    arrayCallbackFn,
     joined,
     escapePaths,
     useArraySelector

--- a/src/index.js
+++ b/src/index.js
@@ -73,8 +73,8 @@ const find = (haystack, searches, pathIn, parents, ctx) => {
 
 module.exports = (needles, {
   filterFn = undefined,
-  breakFn = undefined,
   callbackFn = undefined,
+  breakFn = undefined,
   joined = true,
   escapePaths = true,
   useArraySelector = true
@@ -82,8 +82,8 @@ module.exports = (needles, {
   const search = compiler.compile(new Set(needles)); // keep separate for performance
   return haystack => find(haystack, [search], [], [], {
     filterFn,
-    breakFn,
     callbackFn,
+    breakFn,
     joined,
     escapePaths,
     useArraySelector

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -394,6 +394,26 @@ describe('Testing Find', () => {
     it('Testing useArraySelector = true, breakFn', () => {
       expect(execTest(true, () => false)).to.deep.equal(['', 'child', 'child[0]', 'child[0].id']);
     });
+
+    it('Testing useArraySelector = false invokes breakFn but not callbackFn', () => {
+      const result = [];
+      objectScan(['**'], {
+        useArraySelector: false,
+        callbackFn: k => result.push(['callbackFn', k]),
+        breakFn: k => result.push(['breakFn', k])
+      })({
+        tag: [[{ id: 1 }]]
+      });
+      expect(result).to.deep.equal([
+        ['breakFn', ''],
+        ['breakFn', 'tag'],
+        ['breakFn', 'tag[0]'],
+        ['breakFn', 'tag[0][0]'],
+        ['breakFn', 'tag[0][0].id'],
+        ['callbackFn', 'tag[0][0].id'],
+        ['callbackFn', 'tag[0][0]']
+      ]);
+    });
   });
 
   describe('Testing Fn traversedBy', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -313,51 +313,6 @@ describe('Testing Find', () => {
     });
   });
 
-  describe('Testing arrayCallbackFn', () => {
-    const input = {
-      array: [{ id: 1 }, { id: 2 }]
-    };
-    const tester = (useArraySelector, needles) => {
-      const result = {
-        default: [],
-        array: []
-      };
-      objectScan(needles, {
-        useArraySelector,
-        callbackFn: (k, v) => {
-          result.default.push(k);
-        },
-        arrayCallbackFn: (k, v) => {
-          result.array.push(k);
-        }
-      })(input);
-      return result;
-    };
-
-    it('Testing arrayCallbackFn with useArraySelector == true', () => {
-      expect(tester(true, ['array'])).to.deep.equal({
-        default: ['array'],
-        array: []
-      });
-    });
-
-    describe('Testing arrayCallbackFn with useArraySelector == false', () => {
-      it('Test arrayCallbackFn, matched array', () => {
-        expect(tester(false, ['array'])).to.deep.equal({
-          default: ['array[0]', 'array[1]'],
-          array: ['array']
-        });
-      });
-
-      it('Test arrayCallbackFn, not matched array', () => {
-        expect(tester(false, ['array.id'])).to.deep.equal({
-          default: ['array[0].id', 'array[1].id'],
-          array: []
-        });
-      });
-    });
-  });
-
   describe('Testing Fn parents', () => {
     describe('Testing Object Target', () => {
       const input = { one: [{ child: 'b' }] };


### PR DESCRIPTION
BREAKING CHANGE:
Removed arrayCallbackFn. Was an edge case and hard to understand
function. Same functionality can be achieved using
breakFn and checking if the value / parent is an Array.