### PR TITLE
chore: removed escapePaths option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,6 @@ Setting this to `false` improves performance.
 
 Note that [_.get](https://lodash.com/docs/#get) and [_.set](https://lodash.com/docs/#set) fully support lists.
 
-#### escapePaths
-
-Type: `boolean`<br>
-Default: `true`
-
-When set to false, joined paths for functions and the final result are not escaped.
-
 #### useArraySelector
 
 Type: `boolean`<br>

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const isWildcardMatch = (wildcard, key, isArray, subSearch) => {
 };
 
 const formatPath = (input, ctx) => (ctx.joined ? input.reduce(
-  (p, c) => `${p}${typeof c === 'number' ? `[${c}]` : `${p ? '.' : ''}${ctx.escapePaths ? escape(c) : c}`}`,
+  (p, c) => `${p}${typeof c === 'number' ? `[${c}]` : `${p ? '.' : ''}${escape(c)}`}`,
   ''
 ) : input);
 
@@ -92,15 +92,13 @@ module.exports = (needles, opts = {}) => {
     filterFn: undefined,
     breakFn: undefined,
     joined: true,
-    escapePaths: true,
     useArraySelector: true,
     strict: true
   }, opts);
-  assert(Object.keys(ctx).length === 6, 'Unexpected Option provided!');
+  assert(Object.keys(ctx).length === 5, 'Unexpected Option provided!');
   assert(['function', 'undefined'].includes(typeof ctx.filterFn));
   assert(['function', 'undefined'].includes(typeof ctx.breakFn));
   assert(typeof ctx.joined === 'boolean');
-  assert(typeof ctx.escapePaths === 'boolean');
   assert(typeof ctx.useArraySelector === 'boolean');
   assert(typeof ctx.strict === 'boolean');
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -675,10 +675,10 @@ describe('Testing Find', () => {
       ]);
     });
 
-    it('Testing Output not Escaped', () => {
-      const find = objectScan(['*'], { escapePaths: false });
+    it('Testing Output Escaped', () => {
+      const find = objectScan(['*']);
       expect(find({ 'some.key': '' })).to.deep.equal([
-        'some.key'
+        'some\\.key'
       ]);
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: removed escapePaths options, use join on result instead